### PR TITLE
RAINCATCH-422: Use published version of fh-js-sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - npm install grunt-cli -g
 script:
   - npm test
-  - nsp check
-  - bash <(curl https://gist.githubusercontent.com/feedhenry-raincacher/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+  - nsp check; exit 0
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
 install: npm install
 notifications:
   email: false

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,272 +4,272 @@
   "dependencies": {
     "accepts": {
       "version": "1.3.3",
-      "from": "accepts@>=1.3.3 <1.4.0",
+      "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
     },
     "angular": {
       "version": "1.5.3",
-      "from": "angular@1.5.3",
+      "from": "https://registry.npmjs.org/angular/-/angular-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.3.tgz"
     },
     "angular-animate": {
       "version": "1.5.3",
-      "from": "angular-animate@1.5.3",
+      "from": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/angular-animate/-/angular-animate-1.5.3.tgz"
     },
     "angular-aria": {
       "version": "1.5.3",
-      "from": "angular-aria@1.5.3",
+      "from": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/angular-aria/-/angular-aria-1.5.3.tgz"
     },
     "angular-material": {
       "version": "1.0.7",
-      "from": "angular-material@1.0.7",
+      "from": "https://registry.npmjs.org/angular-material/-/angular-material-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.0.7.tgz"
     },
     "angular-messages": {
       "version": "1.5.3",
-      "from": "angular-messages@1.5.3",
+      "from": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz",
       "resolved": "https://registry.npmjs.org/angular-messages/-/angular-messages-1.5.3.tgz"
     },
     "angular-timeago": {
       "version": "0.2.4",
-      "from": "angular-timeago@0.2.4",
+      "from": "https://registry.npmjs.org/angular-timeago/-/angular-timeago-0.2.4.tgz",
       "resolved": "https://registry.npmjs.org/angular-timeago/-/angular-timeago-0.2.4.tgz"
     },
     "angular-ui-router": {
       "version": "0.2.18",
-      "from": "angular-ui-router@0.2.18",
+      "from": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.2.18.tgz",
       "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-0.2.18.tgz"
     },
     "append-field": {
       "version": "0.1.0",
-      "from": "append-field@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz"
     },
     "array-flatten": {
       "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
+      "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@1.5.2",
+      "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "base64-stream": {
       "version": "0.1.3",
-      "from": "base64-stream@0.1.3",
+      "from": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.3.tgz"
     },
     "body-parser": {
       "version": "1.15.0",
-      "from": "body-parser@1.15.0",
+      "from": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "busboy": {
       "version": "0.2.13",
-      "from": "busboy@>=0.2.11 <0.3.0",
+      "from": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "bytes": {
       "version": "2.2.0",
-      "from": "bytes@2.2.0",
+      "from": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
     },
     "c3": {
       "version": "0.4.11",
-      "from": "c3@0.4.11",
+      "from": "https://registry.npmjs.org/c3/-/c3-0.4.11.tgz",
       "resolved": "https://registry.npmjs.org/c3/-/c3-0.4.11.tgz"
     },
     "concat-stream": {
       "version": "1.5.2",
-      "from": "concat-stream@>=1.5.0 <2.0.0",
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "config-chain": {
       "version": "1.1.10",
-      "from": "config-chain@1.1.10",
+      "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz"
     },
     "content-disposition": {
       "version": "0.5.1",
-      "from": "content-disposition@0.5.1",
+      "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
     },
     "content-type": {
       "version": "1.0.2",
-      "from": "content-type@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
     },
     "cookie": {
       "version": "0.3.1",
-      "from": "cookie@0.3.1",
+      "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
+      "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "cors": {
       "version": "2.7.1",
-      "from": "cors@2.7.1",
+      "from": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
     },
     "d3": {
       "version": "3.5.16",
-      "from": "d3@3.5.16",
+      "from": "https://registry.npmjs.org/d3/-/d3-3.5.16.tgz",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.16.tgz"
     },
     "debug": {
       "version": "2.2.0",
-      "from": "debug@>=2.2.0 <2.3.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
     },
     "depd": {
       "version": "1.1.0",
-      "from": "depd@>=1.1.0 <1.2.0",
+      "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
+      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
     },
     "dicer": {
       "version": "0.2.5",
-      "from": "dicer@0.2.5",
+      "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-        },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "ee-first@1.1.1",
+      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
     },
     "encodeurl": {
       "version": "1.0.1",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
+      "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
     },
     "etag": {
       "version": "1.7.0",
-      "from": "etag@>=1.7.0 <1.8.0",
+      "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
     },
     "express": {
       "version": "4.14.0",
-      "from": "express@4.14.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
         "qs": {
           "version": "6.2.0",
-          "from": "qs@6.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         }
       }
     },
     "fh-js-sdk": {
-      "version": "2.17.4",
-      "from": "git+https://github.com/feedhenry/fh-js-sdk.git",
-      "resolved": "git+https://github.com/feedhenry/fh-js-sdk.git#eda89ed3a50282525c57b7980c76c465a8ec86c0",
+      "version": "2.17.5",
+      "from": "fh-js-sdk@2.17.5",
+      "resolved": "https://registry.npmjs.org/fh-js-sdk/-/fh-js-sdk-2.17.5.tgz",
       "dependencies": {
-        "loglevel": {
-          "version": "0.6.0",
-          "from": "loglevel@~0.6.0",
-          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz"
-        },
-        "process": {
-          "version": "0.6.0",
-          "from": "process@~0.6.0",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
-        },
         "type-of": {
           "version": "2.0.1",
-          "from": "type-of@~2.0.1",
+          "from": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz"
+        },
+        "loglevel": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@~1.6.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+        },
+        "process": {
+          "version": "0.6.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
         }
       }
     },
     "fh-mbaas-api": {
       "version": "5.14.2",
-      "from": "fh-mbaas-api@5.14.2",
+      "from": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.14.2.tgz",
       "resolved": "https://registry.npmjs.org/fh-mbaas-api/-/fh-mbaas-api-5.14.2.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@0.6.2",
+          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "cycle": {
           "version": "1.0.3",
-          "from": "cycle@1.0.3",
+          "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
         },
         "eyes": {
           "version": "0.1.8",
-          "from": "eyes@0.1.8",
+          "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
           "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
         },
         "fh-db": {
           "version": "1.2.3",
-          "from": "fh-db@1.2.3",
+          "from": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/fh-db/-/fh-db-1.2.3.tgz",
           "dependencies": {
             "adm-zip": {
@@ -331,11 +331,6 @@
                         }
                       }
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
                     "minimatch": {
                       "version": "3.0.3",
                       "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
@@ -387,44 +382,7 @@
                 "readable-stream": {
                   "version": "2.1.5",
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz"
                 },
                 "tar-stream": {
                   "version": "1.5.2",
@@ -439,39 +397,7 @@
                         "readable-stream": {
                           "version": "2.0.6",
                           "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.7",
-                              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
                         }
                       }
                     },
@@ -577,15 +503,15 @@
                       "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                       "dependencies": {
-                        "resolve-from": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
-                        },
                         "semver": {
                           "version": "5.3.0",
                           "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                        },
+                        "resolve-from": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                         }
                       }
                     }
@@ -596,25 +522,10 @@
                   "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
                   "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
                     "isarray": {
                       "version": "0.0.1",
                       "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     }
                   }
                 }
@@ -629,7 +540,7 @@
         },
         "fh-mbaas-client": {
           "version": "0.15.0",
-          "from": "fh-mbaas-client@0.15.0",
+          "from": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
           "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-0.15.0.tgz",
           "dependencies": {
             "fh-logger": {
@@ -646,103 +557,65 @@
                       "version": "0.6.0",
                       "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
                       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
-                      "optional": true,
                       "dependencies": {
                         "nan": {
                           "version": "2.3.5",
                           "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
-                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
                         }
                       }
-                    },
-                    "moment": {
-                      "version": "2.13.0",
-                      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
-                      "optional": true
                     },
                     "mv": {
                       "version": "2.1.1",
                       "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-                      "optional": true,
                       "dependencies": {
-                        "mkdirp": {
-                          "version": "0.5.1",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                          "optional": true,
-                          "dependencies": {
-                            "minimist": {
-                              "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                              "optional": true
-                            }
-                          }
-                        },
                         "ncp": {
                           "version": "2.0.0",
                           "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                         },
                         "rimraf": {
                           "version": "2.4.5",
                           "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                          "optional": true,
                           "dependencies": {
                             "glob": {
                               "version": "6.0.4",
                               "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                              "optional": true,
                               "dependencies": {
                                 "inflight": {
                                   "version": "1.0.5",
                                   "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                                  "optional": true,
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
                                       "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                      "optional": true
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                                  "optional": true
                                 },
                                 "minimatch": {
                                   "version": "3.0.2",
                                   "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-                                  "optional": true,
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.5",
                                       "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-                                      "optional": true,
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.4.1",
                                           "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
-                                          "optional": true
+                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
                                           "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                          "optional": true
+                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                         }
                                       }
                                     }
@@ -763,8 +636,7 @@
                                 "path-is-absolute": {
                                   "version": "1.0.0",
                                   "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                                  "optional": true
+                                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                                 }
                               }
                             }
@@ -775,8 +647,12 @@
                     "safe-json-stringify": {
                       "version": "1.0.3",
                       "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz"
+                    },
+                    "moment": {
+                      "version": "2.13.0",
+                      "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                      "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz"
                     }
                   }
                 },
@@ -827,7 +703,7 @@
         },
         "fh-mbaas-express": {
           "version": "5.6.3",
-          "from": "fh-mbaas-express@5.6.3",
+          "from": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.3.tgz",
           "resolved": "https://registry.npmjs.org/fh-mbaas-express/-/fh-mbaas-express-5.6.3.tgz",
           "dependencies": {
             "body-parser": {
@@ -840,38 +716,11 @@
                   "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
                 },
-                "content-type": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "depd": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-                },
                 "http-errors": {
                   "version": "1.5.0",
                   "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                   "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
                     "setprototypeof": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
@@ -884,63 +733,15 @@
                     }
                   }
                 },
-                "iconv-lite": {
-                  "version": "0.4.13",
-                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                    }
-                  }
-                },
                 "qs": {
                   "version": "6.2.0",
                   "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
-                "raw-body": {
-                  "version": "2.1.7",
-                  "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-                  "dependencies": {
-                    "unpipe": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                    }
-                  }
-                },
                 "type-is": {
                   "version": "1.6.13",
                   "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-                  "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
                 }
               }
             },
@@ -948,258 +749,6 @@
               "version": "2.1.0",
               "from": "https://registry.npmjs.org/cors/-/cors-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cors/-/cors-2.1.0.tgz"
-            },
-            "express": {
-              "version": "4.14.0",
-              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
-              "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
-              "dependencies": {
-                "accepts": {
-                  "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-                  "dependencies": {
-                    "mime-types": {
-                      "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-                        }
-                      }
-                    },
-                    "negotiator": {
-                      "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                    }
-                  }
-                },
-                "array-flatten": {
-                  "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-                  "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-                },
-                "content-disposition": {
-                  "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
-                  "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
-                },
-                "content-type": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-                },
-                "cookie": {
-                  "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-                },
-                "cookie-signature": {
-                  "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-                },
-                "debug": {
-                  "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    }
-                  }
-                },
-                "depd": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-                },
-                "encodeurl": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-                },
-                "etag": {
-                  "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
-                },
-                "finalhandler": {
-                  "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-                  "dependencies": {
-                    "statuses": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
-                    },
-                    "unpipe": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                    }
-                  }
-                },
-                "fresh": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
-                },
-                "merge-descriptors": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-                },
-                "methods": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                    }
-                  }
-                },
-                "parseurl": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-                },
-                "path-to-regexp": {
-                  "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-                  "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-                },
-                "proxy-addr": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
-                  "dependencies": {
-                    "forwarded": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
-                    },
-                    "ipaddr.js": {
-                      "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "6.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
-                },
-                "range-parser": {
-                  "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-                },
-                "send": {
-                  "version": "0.14.1",
-                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
-                  "dependencies": {
-                    "destroy": {
-                      "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-                    },
-                    "http-errors": {
-                      "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-                      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "setprototypeof": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.3.4",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                    },
-                    "ms": {
-                      "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                    },
-                    "statuses": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
-                    }
-                  }
-                },
-                "serve-static": {
-                  "version": "1.11.1",
-                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
-                  "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
-                },
-                "type-is": {
-                  "version": "1.6.13",
-                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
-                  "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                },
-                "vary": {
-                  "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
-                }
-              }
             },
             "fh-amqp-js": {
               "version": "0.7.0",
@@ -1238,16 +787,6 @@
                   "from": "https://registry.npmjs.org/rc/-/rc-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/rc/-/rc-0.1.1.tgz",
                   "dependencies": {
-                    "deep-extend": {
-                      "version": "0.2.11",
-                      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
-                    },
-                    "ini": {
-                      "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
-                    },
                     "optimist": {
                       "version": "0.3.7",
                       "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
@@ -1259,6 +798,16 @@
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "ini": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
                     }
                   }
                 }
@@ -1281,52 +830,6 @@
               "from": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
               "dependencies": {
-                "busboy": {
-                  "version": "0.2.13",
-                  "from": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
-                  "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.13.tgz",
-                  "dependencies": {
-                    "dicer": {
-                      "version": "0.2.5",
-                      "from": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-                      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-                      "dependencies": {
-                        "streamsearch": {
-                          "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "1.1.14",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
                 "mkdirp": {
                   "version": "0.3.5",
                   "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
@@ -1342,11 +845,6 @@
                   "from": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
                   "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                    },
                     "mime-types": {
                       "version": "2.0.14",
                       "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
@@ -1384,7 +882,7 @@
         },
         "fh-security": {
           "version": "0.2.0",
-          "from": "fh-security@0.2.0",
+          "from": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/fh-security/-/fh-security-0.2.0.tgz",
           "dependencies": {
             "node-rsa": {
@@ -1403,51 +901,51 @@
         },
         "fh-statsc": {
           "version": "0.3.0",
-          "from": "fh-statsc@0.3.0",
+          "from": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/fh-statsc/-/fh-statsc-0.3.0.tgz"
         },
         "lodash-contrib": {
           "version": "393.0.1",
-          "from": "lodash-contrib@>=393.0.1 <394.0.0",
+          "from": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-393.0.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.9.3",
-              "from": "lodash@3.9.3",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.3.tgz"
             }
           }
         },
         "memcached": {
           "version": "2.2.2",
-          "from": "memcached@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
           "resolved": "https://registry.npmjs.org/memcached/-/memcached-2.2.2.tgz",
           "dependencies": {
             "hashring": {
               "version": "3.2.0",
-              "from": "hashring@>=3.2.0 <3.3.0",
+              "from": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
               "dependencies": {
                 "connection-parse": {
                   "version": "0.0.7",
-                  "from": "connection-parse@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/connection-parse/-/connection-parse-0.0.7.tgz"
                 },
                 "simple-lru-cache": {
                   "version": "0.0.2",
-                  "from": "simple-lru-cache@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz"
                 }
               }
             },
             "jackpot": {
               "version": "0.0.6",
-              "from": "jackpot@>=0.0.6",
+              "from": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
               "dependencies": {
                 "retry": {
                   "version": "0.6.0",
-                  "from": "retry@0.6.0",
+                  "from": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
                 }
               }
@@ -1456,83 +954,58 @@
         },
         "moment": {
           "version": "2.14.1",
-          "from": "moment@2.14.1",
+          "from": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
         },
         "mongodb-uri": {
           "version": "0.9.7",
-          "from": "mongodb-uri@0.9.7",
+          "from": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
           "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
         },
         "optval": {
           "version": "1.0.1",
-          "from": "optval@1.0.1",
+          "from": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/optval/-/optval-1.0.1.tgz"
         },
         "pkginfo": {
           "version": "0.2.3",
-          "from": "pkginfo@0.2.3",
+          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
         },
         "redis": {
           "version": "0.8.2",
-          "from": "redis@0.8.2",
+          "from": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz"
         },
         "request": {
           "version": "2.74.0",
-          "from": "request@2.74.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.5.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
             },
             "bl": {
               "version": "1.1.2",
-              "from": "bl@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -1540,44 +1013,44 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.1",
-              "from": "form-data@>=1.0.0-rc4 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "2.1.2",
-                  "from": "async@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz",
                   "dependencies": {
                     "lodash": {
                       "version": "4.16.4",
-                      "from": "lodash@>=4.14.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
                     }
                   }
@@ -1586,104 +1059,104 @@
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.15.0",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "4.0.0",
-                      "from": "jsonpointer@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
@@ -1692,117 +1165,112 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.3.1",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.10.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.0",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "optional": true
                     },
                     "dashdash": {
                       "version": "1.14.0",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "optional": true
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "optional": true
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "optional": true
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.14.3",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "optional": true
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                     }
                   }
                 }
@@ -1810,76 +1278,64 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.12",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-                }
-              }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
               "version": "6.2.1",
-              "from": "qs@>=6.2.0 <6.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.3.1",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
         },
         "stack-trace": {
           "version": "0.0.9",
-          "from": "stack-trace@0.0.9",
+          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
         },
         "underscore": {
           "version": "1.7.0",
-          "from": "underscore@1.7.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
         },
         "unifiedpush-node-sender": {
           "version": "0.12.0",
-          "from": "unifiedpush-node-sender@0.12.0",
+          "from": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
           "resolved": "https://registry.npmjs.org/unifiedpush-node-sender/-/unifiedpush-node-sender-0.12.0.tgz",
           "dependencies": {
             "lodash": {
@@ -1919,16 +1375,6 @@
                       "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                       "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
                         "isarray": {
                           "version": "0.0.1",
                           "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1938,16 +1384,6 @@
                           "version": "1.0.6",
                           "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
@@ -2103,6 +1539,11 @@
                   "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                   "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
                     "boom": {
                       "version": "2.10.1",
                       "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -2112,11 +1553,6 @@
                       "version": "2.0.5",
                       "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                     },
                     "sntp": {
                       "version": "1.0.9",
@@ -2172,29 +1608,25 @@
                           "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz",
                           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.12.2.tgz"
                         },
-                        "ecc-jsbn": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                          "optional": true
-                        },
-                        "jodid25519": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                          "optional": true
-                        },
                         "jsbn": {
                           "version": "0.1.0",
                           "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                         },
                         "tweetnacl": {
                           "version": "0.13.3",
                           "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                          "optional": true
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                         }
                       }
                     }
@@ -2263,423 +1695,418 @@
         },
         "winston": {
           "version": "0.8.0",
-          "from": "winston@0.8.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
           "dependencies": {
             "pkginfo": {
               "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
             }
           }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "from": "xtend@4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "fh-wfm-analytics": {
       "version": "0.0.7",
-      "from": "fh-wfm-analytics@0.0.7",
+      "from": "https://registry.npmjs.org/fh-wfm-analytics/-/fh-wfm-analytics-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-analytics/-/fh-wfm-analytics-0.0.7.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.2",
-          "from": "lodash@>=4.16.4 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
         }
       }
     },
     "fh-wfm-appform": {
       "version": "0.0.24",
-      "from": "fh-wfm-appform@0.0.24",
+      "from": "https://registry.npmjs.org/fh-wfm-appform/-/fh-wfm-appform-0.0.24.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-appform/-/fh-wfm-appform-0.0.24.tgz"
     },
     "fh-wfm-camera": {
       "version": "0.0.8",
-      "from": "fh-wfm-camera@0.0.8",
+      "from": "https://registry.npmjs.org/fh-wfm-camera/-/fh-wfm-camera-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-camera/-/fh-wfm-camera-0.0.8.tgz",
       "dependencies": {
         "lodash": {
           "version": "4.17.2",
-          "from": "lodash@>=4.16.4 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
         }
       }
     },
     "fh-wfm-file": {
       "version": "0.0.7",
-      "from": "fh-wfm-file@0.0.7",
+      "from": "https://registry.npmjs.org/fh-wfm-file/-/fh-wfm-file-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-file/-/fh-wfm-file-0.0.7.tgz"
     },
     "fh-wfm-map": {
       "version": "0.0.8",
-      "from": "fh-wfm-map@0.0.8",
+      "from": "https://registry.npmjs.org/fh-wfm-map/-/fh-wfm-map-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-map/-/fh-wfm-map-0.0.8.tgz"
     },
     "fh-wfm-mediator": {
       "version": "0.0.15",
-      "from": "fh-wfm-mediator@0.0.15",
+      "from": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.0.15.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-mediator/-/fh-wfm-mediator-0.0.15.tgz"
     },
     "fh-wfm-message": {
       "version": "0.0.15",
-      "from": "fh-wfm-message@0.0.15",
+      "from": "https://registry.npmjs.org/fh-wfm-message/-/fh-wfm-message-0.0.15.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-message/-/fh-wfm-message-0.0.15.tgz"
     },
     "fh-wfm-result": {
       "version": "0.0.16",
-      "from": "fh-wfm-result@0.0.16",
+      "from": "https://registry.npmjs.org/fh-wfm-result/-/fh-wfm-result-0.0.16.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-result/-/fh-wfm-result-0.0.16.tgz"
     },
     "fh-wfm-risk-assessment": {
       "version": "0.0.14",
-      "from": "fh-wfm-risk-assessment@0.0.14",
+      "from": "https://registry.npmjs.org/fh-wfm-risk-assessment/-/fh-wfm-risk-assessment-0.0.14.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-risk-assessment/-/fh-wfm-risk-assessment-0.0.14.tgz"
     },
     "fh-wfm-schedule": {
       "version": "0.0.11",
-      "from": "fh-wfm-schedule@0.0.11",
+      "from": "https://registry.npmjs.org/fh-wfm-schedule/-/fh-wfm-schedule-0.0.11.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-schedule/-/fh-wfm-schedule-0.0.11.tgz"
     },
     "fh-wfm-signature": {
       "version": "0.0.15",
-      "from": "fh-wfm-signature@0.0.15",
+      "from": "https://registry.npmjs.org/fh-wfm-signature/-/fh-wfm-signature-0.0.15.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-signature/-/fh-wfm-signature-0.0.15.tgz"
     },
     "fh-wfm-sync": {
       "version": "0.0.16",
-      "from": "fh-wfm-sync@0.0.16",
+      "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.16.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.16.tgz"
     },
     "fh-wfm-user": {
       "version": "0.0.25",
-      "from": "fh-wfm-user@0.0.25",
+      "from": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.0.25.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-user/-/fh-wfm-user-0.0.25.tgz"
     },
     "fh-wfm-vehicle-inspection": {
       "version": "0.0.12",
-      "from": "fh-wfm-vehicle-inspection@0.0.12",
+      "from": "https://registry.npmjs.org/fh-wfm-vehicle-inspection/-/fh-wfm-vehicle-inspection-0.0.12.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-vehicle-inspection/-/fh-wfm-vehicle-inspection-0.0.12.tgz"
     },
     "fh-wfm-workflow": {
       "version": "0.0.26",
-      "from": "fh-wfm-workflow@0.0.26",
+      "from": "https://registry.npmjs.org/fh-wfm-workflow/-/fh-wfm-workflow-0.0.26.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-workflow/-/fh-wfm-workflow-0.0.26.tgz"
     },
     "fh-wfm-workorder": {
       "version": "0.0.27",
-      "from": "fh-wfm-workorder@0.0.27",
+      "from": "https://registry.npmjs.org/fh-wfm-workorder/-/fh-wfm-workorder-0.0.27.tgz",
       "resolved": "https://registry.npmjs.org/fh-wfm-workorder/-/fh-wfm-workorder-0.0.27.tgz",
       "dependencies": {
         "fh-wfm-sync": {
           "version": "0.0.14",
-          "from": "fh-wfm-sync@0.0.14",
+          "from": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.14.tgz",
           "resolved": "https://registry.npmjs.org/fh-wfm-sync/-/fh-wfm-sync-0.0.14.tgz"
         }
       }
     },
     "finalhandler": {
       "version": "0.5.0",
-      "from": "finalhandler@0.5.0",
+      "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
     },
     "forwarded": {
       "version": "0.1.0",
-      "from": "forwarded@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
     },
     "fresh": {
       "version": "0.3.0",
-      "from": "fresh@0.3.0",
+      "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
     },
     "http-errors": {
       "version": "1.4.0",
-      "from": "http-errors@>=1.4.0 <1.5.0",
+      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
     },
     "iconv-lite": {
       "version": "0.4.13",
-      "from": "iconv-lite@0.4.13",
+      "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@2.0.1",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.4 <2.0.0",
+      "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "ipaddr.js": {
       "version": "1.1.1",
-      "from": "ipaddr.js@1.1.1",
+      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "lodash": {
       "version": "4.7.0",
-      "from": "lodash@4.7.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.7.0.tgz"
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "media-typer@0.3.0",
+      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
     },
     "mediator-js": {
       "version": "0.9.9",
-      "from": "mediator-js@>=0.9.9 <0.10.0",
+      "from": "https://registry.npmjs.org/mediator-js/-/mediator-js-0.9.9.tgz",
       "resolved": "https://registry.npmjs.org/mediator-js/-/mediator-js-0.9.9.tgz"
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "from": "merge-descriptors@1.0.1",
+      "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
     },
     "mime": {
       "version": "1.3.4",
-      "from": "mime@1.3.4",
+      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
     },
     "mime-db": {
       "version": "1.24.0",
-      "from": "mime-db@>=1.24.0 <1.25.0",
+      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
     },
     "mime-types": {
       "version": "2.1.12",
-      "from": "mime-types@>=2.1.11 <2.2.0",
+      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8",
+      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "moment": {
       "version": "2.16.0",
-      "from": "moment@>=2.16.0 <3.0.0",
+      "from": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.16.0.tgz"
     },
     "ms": {
       "version": "0.7.1",
-      "from": "ms@0.7.1",
+      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "multer": {
       "version": "1.1.0",
-      "from": "multer@1.1.0",
+      "from": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.1.0.tgz"
     },
     "negotiator": {
       "version": "0.6.1",
-      "from": "negotiator@0.6.1",
+      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
     "ng-feedhenry": {
       "version": "0.3.0",
-      "from": "ng-feedhenry@0.3.0",
+      "from": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/ng-feedhenry/-/ng-feedhenry-0.3.0.tgz"
     },
     "ng-sortable": {
       "version": "1.3.4",
-      "from": "ng-sortable@1.3.4",
+      "from": "https://registry.npmjs.org/ng-sortable/-/ng-sortable-1.3.4.tgz",
       "resolved": "https://registry.npmjs.org/ng-sortable/-/ng-sortable-1.3.4.tgz"
     },
     "object-assign": {
       "version": "3.0.0",
-      "from": "object-assign@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
+      "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
     },
     "parseurl": {
       "version": "1.3.1",
-      "from": "parseurl@>=1.3.1 <1.4.0",
+      "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
+      "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "proto-list": {
       "version": "1.2.4",
-      "from": "proto-list@>=1.2.1 <1.3.0",
+      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
     },
     "proxy-addr": {
       "version": "1.1.2",
-      "from": "proxy-addr@>=1.1.2 <1.2.0",
+      "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
     },
     "q": {
       "version": "1.4.1",
-      "from": "q@1.4.1",
+      "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
     },
     "qs": {
       "version": "6.1.0",
-      "from": "qs@6.1.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
     },
     "range-parser": {
       "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
+      "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
     },
     "raw-body": {
       "version": "2.1.7",
-      "from": "raw-body@>=2.1.5 <2.2.0",
+      "from": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.4.0",
-          "from": "bytes@2.4.0",
+          "from": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
         }
       }
     },
     "readable-stream": {
       "version": "2.2.2",
-      "from": "readable-stream@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
     },
     "rx": {
       "version": "4.1.0",
-      "from": "rx@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
     },
     "send": {
       "version": "0.14.1",
-      "from": "send@0.14.1",
+      "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
       "dependencies": {
         "http-errors": {
           "version": "1.5.1",
-          "from": "http-errors@>=1.5.0 <1.6.0",
+          "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@2.0.3",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         }
       }
     },
     "serve-static": {
       "version": "1.11.1",
-      "from": "serve-static@>=1.11.1 <1.12.0",
+      "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
     },
     "setprototypeof": {
       "version": "1.0.2",
-      "from": "setprototypeof@1.0.2",
+      "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
     },
     "shortid": {
       "version": "2.2.6",
-      "from": "shortid@>=2.2.6 <3.0.0",
+      "from": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.6.tgz"
     },
     "statuses": {
       "version": "1.3.1",
-      "from": "statuses@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
     },
     "streamsearch": {
       "version": "0.1.2",
-      "from": "streamsearch@0.1.2",
+      "from": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "through2": {
       "version": "2.0.1",
-      "from": "through2@2.0.1",
+      "from": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
     "type-is": {
       "version": "1.6.13",
-      "from": "type-is@>=1.6.11 <1.7.0",
+      "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "underscore": {
       "version": "1.8.3",
-      "from": "underscore@>=1.8.3 <2.0.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@1.0.0",
+      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "utils-merge": {
       "version": "1.0.0",
-      "from": "utils-merge@1.0.0",
+      "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
     },
     "uuid-js": {
       "version": "0.7.5",
-      "from": "uuid-js@0.7.5",
+      "from": "https://registry.npmjs.org/uuid-js/-/uuid-js-0.7.5.tgz",
       "resolved": "https://registry.npmjs.org/uuid-js/-/uuid-js-0.7.5.tgz"
     },
     "vary": {
       "version": "1.1.0",
-      "from": "vary@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cors": "2.7.1",
     "d3": "3.5.16",
     "express": "4.14.0",
-    "fh-js-sdk": "git+https://github.com/feedhenry/fh-js-sdk.git",
+    "fh-js-sdk": "2.17.5",
     "fh-wfm-analytics": "0.0.7",
     "fh-wfm-appform": "0.0.24",
     "fh-wfm-camera": "0.0.8",


### PR DESCRIPTION
## What
Raincatcher-demo-portal is using the head version of fh-js-sdk. Modified to use the latest published version of fh-js-sdk instead

## JIRA TIcket
https://issues.jboss.org/browse/RAINCATCH-422