### PR TITLE
Added a new settings section to the portal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "rules": {
@@ -27,6 +28,8 @@
   },
   "globals": {
     "angular": false,
+    "window": true,
+    "inject": true
   }
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 www/
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,6 +167,15 @@ module.exports = function (grunt) {
 
     eslint: {
       src: ['application.js', 'src/**/*.js']
+    },
+
+    mochify: {
+      options: {
+        reporter: 'spec'
+      },
+      unit: {
+        src: ['src/app/**/*-spec.js']
+      }
     }
   });
 
@@ -185,6 +194,8 @@ module.exports = function (grunt) {
       'build', 'connect:livereload', 'watch'
     ]);
   });
+
+  grunt.registerTask('test', ['eslint', 'mochify:unit']);
 
   grunt.registerTask('build', ['clean:dist', 'sass', 'copy', 'clean:server', 'browserify']);
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "application.js",
   "scripts": {
     "start": "node application.js",
-    "test": "grunt eslint"
+    "test": "grunt test"
   },
   "keywords": [
     "wfm"
@@ -59,7 +59,10 @@
   },
   "devDependencies": {
     "browserify-ngannotate": "^2.0.0",
+    "should": "8.3.0",
     "grunt": "0.4.5",
+    "angular-mocks": "^1.5.8",
+    "grunt-mochify": "^0.3.0",
     "grunt-browserify": "5.0.0",
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-connect": "1.0.1",
@@ -71,6 +74,8 @@
     "grunt-sass": "1.1.0",
     "load-grunt-tasks": "3.4.1",
     "time-grunt": "1.3.0",
-    "uglifyify": "^3.0.1"
+    "uglifyify": "^3.0.1",
+    "sinon": "1.17.6",
+    "sinon-as-promised": "4.0.2"
   }
 }

--- a/src/app/feedhenry/feedhenryService.js
+++ b/src/app/feedhenry/feedhenryService.js
@@ -1,0 +1,5 @@
+
+
+angular.module('app.feedhenry').service('$fh', function() {
+  return window.$fh;
+});

--- a/src/app/feedhenry/index.js
+++ b/src/app/feedhenry/index.js
@@ -1,0 +1,6 @@
+angular.module('app.feedhenry', []);
+
+require('./feedhenryService');
+
+module.exports = 'app.feedhenry';
+

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -5,7 +5,8 @@ require('feedhenry');
 
 angular.module('app', [
   require('angular-ui-router')
-, require('angular-material')
+, require('angular-material'),
+  require('./feedhenry')
 , require('fh-wfm-mediator')
 , require('fh-wfm-workorder')
 , require('fh-wfm-result')
@@ -33,6 +34,8 @@ angular.module('app', [
 , require('./schedule/schedule')
 , require('./map/map')
 , require('./analytics/analytics')
+  //Settings view
+  , require('./settings')
 ])
 
 .config(function($stateProvider, $urlRouterProvider) {

--- a/src/app/main.tpl.html
+++ b/src/app/main.tpl.html
@@ -52,6 +52,10 @@
           <md-icon md-font-set="material-icons">insert_chart</md-icon>
           <p>Analytics</p>
         </md-list-item>
+        <md-list-item ng-click="navigateTo('app.settings')" ng-class="{active: $state.includes('app.settings')}">
+          <md-icon md-font-set="material-icons">check_box</md-icon>
+          <p>Settings</p>
+        </md-list-item>
 
         <md-divider></md-divider>
 

--- a/src/app/settings/dataResetService-spec.js
+++ b/src/app/settings/dataResetService-spec.js
@@ -1,0 +1,74 @@
+var angular = require('angular');
+var should = require('should');
+var sinon = require('sinon');
+require('sinon-as-promised');
+require('angular-mocks');
+
+
+describe("Settings Module", function() {
+
+  before(function() {
+    angular.module('app.settings', []);
+  });
+
+  describe("Settings Service", function() {
+
+    var DataResetService;
+    var $fh;
+
+    beforeEach(function() {
+      angular.mock.module('app.settings', function($provide) {
+        //Providing the $fh mock service to test the cloud calls.
+        $provide.service('$fh', function() {
+          return {};
+        });
+      });
+    });
+
+    before(function() {
+      require('./dataResetService');
+    });
+
+    beforeEach(inject(function(_DataResetService_, _$fh_) {
+      DataResetService = _DataResetService_;
+      $fh = _$fh_;
+    }));
+
+
+    /**
+     * Checking that the $fh.cloud call was called with the core
+     */
+    function checkCloudCallArguments() {
+      sinon.assert.calledOnce($fh.cloud);
+      sinon.assert.calledWith($fh.cloud, sinon.match({
+        path: sinon.match('/admin/data'),
+        method: sinon.match('delete'),
+        contentType: sinon.match('application/json')
+      }), sinon.match.func, sinon.match.func);
+    }
+
+    it("It should call $fh.cloud to reset the data", function(done) {
+      $fh.cloud = sinon.stub().yields();
+
+      DataResetService.resetData().then(function() {
+        checkCloudCallArguments();
+        done();
+      }).catch(done);
+    });
+
+    it("It should return an error if the reset failed", function(done) {
+      var errorMessage = "Error resetting data";
+      $fh.cloud = sinon.stub().callsArgWith(2, errorMessage);
+
+      DataResetService.resetData().then(function() {
+        done("Should not have succeeded.");
+      }).catch(function(err) {
+        checkCloudCallArguments();
+
+        should(err.message).equal(errorMessage);
+        done();
+      });
+    });
+  });
+});
+

--- a/src/app/settings/dataResetService.js
+++ b/src/app/settings/dataResetService.js
@@ -1,0 +1,39 @@
+var q = require('q');
+
+/**
+ *
+ * A service for resetting all of the data for the portal application.
+ *
+ * WARNING: THIS IS INTENDED FOR DEMO PURPOSES ONLY!! DO NOT INCLUDE THIS IN A PRODUCTION APPLICATION!!
+ */
+
+function DataResetService($fh) {
+  this.$fh = $fh;
+}
+
+/**
+ *
+ * Resetting all data in the application to the original data sets.
+ *
+ * @returns {*}
+ */
+DataResetService.prototype.resetData = function() {
+  var options = {
+    path: '/admin/data',
+    method: 'delete',
+    contentType: 'application/json'
+  };
+
+  var resetDataDefer = q.defer();
+  this.$fh.cloud(options, function(resetDataResponse) {
+    resetDataDefer.resolve(resetDataResponse);
+  }, function(message) {
+    var cloudError = new Error(message);
+    resetDataDefer.reject(cloudError);
+  });
+  return resetDataDefer.promise;
+};
+
+angular.module('app.settings').service('DataResetService', ['$fh', function($fh) {
+  return new DataResetService($fh);
+}]);

--- a/src/app/settings/index.js
+++ b/src/app/settings/index.js
@@ -1,0 +1,11 @@
+module.exports = 'app.settings';
+
+angular.module('app.settings', [
+  'ui.router',
+  'ngMaterial',
+  'app.feedhenry'
+]);
+
+require('./dataResetService');
+require('./settingsController');
+require('./settingsDirective');

--- a/src/app/settings/settings.tpl.html
+++ b/src/app/settings/settings.tpl.html
@@ -1,0 +1,27 @@
+<div class="md-toolbar-tools">
+  <h3>Settings</h3>
+</div>
+
+<div layout="row">
+
+  <md-card>
+    <md-card-title>
+      <md-card-title-text>
+        <span class="md-headline">Reset All Data</span>
+      </md-card-title-text>
+
+    </md-card-title>
+    <md-card-content>
+      <p>
+        <b>Warning!!</b> This will erase <b>ALL</b> data.
+
+        This should not be used in production applications. It is intended for development purposes only.
+      </p>
+    </md-card-content>
+
+    <md-card-actions layout="column" layout-align="start">
+      <md-button ng-click="ctrl.resetData($event)" class="md-raised md-accent md-warn">Reset All Data</md-button>
+    </md-card-actions>
+
+  </md-card>
+</div>

--- a/src/app/settings/settingsController-spec.js
+++ b/src/app/settings/settingsController-spec.js
@@ -1,0 +1,121 @@
+var angular = require('angular');
+var sinon = require('sinon');
+require('sinon-as-promised');
+require('angular-mocks');
+
+
+describe("Settings Controller", function() {
+
+  var DataResetService, $mdDialog, $state, userClient, SettingsController;
+
+  before(function() {
+    angular.module('app.settings', []);
+  });
+
+  before(function() {
+    require('./settingsController');
+  });
+
+  var mockConfirmDialog = {
+    type: "mockConfirm"
+  };
+
+  var mockLogoutDialog = {
+    type: "mockLogout"
+  };
+
+  var mockErrorDialog = {
+    type: "error"
+  };
+
+  var mockAlertDialog;
+
+  beforeEach(function() {
+
+    mockAlertDialog = sinon.stub();
+
+    mockAlertDialog.withArgs(sinon.match({
+      title: sinon.match('Error Resetting Data')
+    })).returns(mockErrorDialog);
+
+    mockAlertDialog.withArgs(sinon.match({
+      title: sinon.match('Data Reset Complete')
+    })).returns(mockLogoutDialog);
+
+    mockAlertDialog.returns(null);
+
+    angular.mock.module('app.settings', function($provide) {
+      //Providing the DataResetService mock service
+      $provide.service('DataResetService', function() {
+        return {
+          resetData: sinon.stub().resolves()
+        };
+      });
+
+      $provide.service('$mdDialog', function() {
+        return {
+          confirm: sinon.stub().returns(mockConfirmDialog),
+          alert: mockAlertDialog,
+          show: sinon.stub().resolves()
+        };
+      });
+
+      $provide.service('$state', function() {
+        return {
+          go: sinon.spy()
+        };
+      });
+
+      $provide.service('userClient', function() {
+        return {
+          clearSession: sinon.stub().resolves()
+        };
+      });
+
+    });
+  });
+
+  describe("Resetting Data ", function() {
+
+    beforeEach(inject(function(_DataResetService_, _$mdDialog_, _$state_, _userClient_, $controller, $rootScope) {
+      DataResetService = _DataResetService_;
+      $mdDialog = _$mdDialog_;
+      $state = _$state_;
+      userClient = _userClient_;
+      SettingsController = $controller('SettingsController', {
+        $scope: $rootScope.$new()
+      });
+    }));
+
+    it("It should reset data after confirmation", function(done) {
+      var mockEvent = {
+        preventDefault: sinon.spy()
+      };
+
+      SettingsController.resetData(mockEvent).then(function() {
+        sinon.assert.calledOnce(mockEvent.preventDefault);
+        sinon.assert.calledOnce($mdDialog.confirm);
+
+        sinon.assert.calledOnce(mockAlertDialog);
+        sinon.assert.calledWith(mockAlertDialog, sinon.match({
+          title: 'Data Reset Complete'
+        }));
+
+        sinon.assert.calledTwice($mdDialog.show);
+        sinon.assert.calledWith($mdDialog.show, mockConfirmDialog);
+        sinon.assert.calledWith($mdDialog.show, mockLogoutDialog);
+
+        sinon.assert.calledOnce(DataResetService.resetData);
+
+        sinon.assert.calledOnce(userClient.clearSession);
+
+        sinon.assert.calledOnce($state.go);
+
+        done();
+      });
+    });
+
+
+  });
+
+});

--- a/src/app/settings/settingsController.js
+++ b/src/app/settings/settingsController.js
@@ -1,0 +1,89 @@
+
+
+
+/**
+ * Creating the confirmation dialog to reset all data.
+ * @param $mdDialog
+ * @param event
+ * @returns {*}
+ */
+function getConfirmDialog($mdDialog, event) {
+  return $mdDialog.confirm({
+    title: 'Are you sure?',
+    textContent: "Are you sure you want to reset ALL data? This is not reversible. Any data that has been created will be removed.",
+    ariaLabel: 'Reset All Data',
+    targetEvent: event,
+    ok: 'Reset All Data',
+    cancel: 'Cancel'
+  });
+}
+
+/**
+ * Creating the dialogue to alert the user that the reset has completed.
+ * @param $mdDialog
+ * @returns {*}
+ */
+function getCompleteAlert($mdDialog) {
+  return $mdDialog.alert({
+    title: 'Data Reset Complete',
+    textContent: 'All data has been reset. Please log in again.',
+    ok: 'Login'
+  });
+}
+
+/**
+ * Creating a dialog to alert the user that there was an error resetting the data.
+ * @param $mdDialog
+ * @param err
+ * @returns {*}
+ */
+function getErrorAlert($mdDialog, err) {
+  return $mdDialog.alert({
+    title: 'Error Resetting Data',
+    textContent: err && err.message ? err.message : "Unknown error",
+    ok: 'Close'
+  });
+}
+
+
+/**
+ * Controller for the settings directive
+ *
+ * NOTE: DO NOT USE IN PRODUCTION. THIS IS FOR DEMO PURPOSES ONLY!
+ *
+ * @param DataResetService (WARNING: DO NOT USE IN PRODUCTION. THIS IS FOR DEMO PURPOSES ONLY! THIS SERVICE CAN REMOVE ALL DATA!)
+ * @param $mdDialog
+ * @param $state
+ * @param userClient
+ * @constructor
+ */
+function SettingsController(DataResetService, $mdDialog, $state, userClient) {
+  var self = this;
+
+  //Function executed to reset ALL data for the solution.
+  self.resetData = function(event) {
+    event.preventDefault();
+
+    //The user must confirm before the request is made to delete the data.
+    return $mdDialog.show(getConfirmDialog($mdDialog, event)).then(function() {
+
+      //Resetting all data ((WARNING: DO NOT USE IN PRODUCTION. THIS IS FOR DEMO PURPOSES ONLY! THIS SERVICE CAN REMOVE ALL DATA!))
+      return DataResetService.resetData().then(function() {
+        //Alert the user that the reset is complete, the user must log in again as users would have been deleted as part of the reset.
+        $mdDialog.show(getCompleteAlert($mdDialog)).then(function() {
+          //Clearing the local user session data to force a login.
+          userClient.clearSession().then(function() {
+            $state.go('app.login');
+          });
+        });
+      }).catch(function(err) {
+        //There was an error resetting the date. Alert the user and allow them to try again.
+        $mdDialog.show(getErrorAlert($mdDialog, err));
+      });
+    });
+  };
+
+}
+
+
+angular.module('app.settings').controller('SettingsController', ['DataResetService', '$mdDialog', '$state', 'userClient', SettingsController]);

--- a/src/app/settings/settingsDirective.js
+++ b/src/app/settings/settingsDirective.js
@@ -1,0 +1,18 @@
+
+'use strict';
+
+angular.module('app.settings').config(function($stateProvider) {
+  $stateProvider
+    .state('app.settings', {
+      url: '/settings',
+      data: {
+        columns: 2
+      },
+      views: {
+        content: {
+          templateUrl: 'app/settings/settings.tpl.html',
+          controller: 'SettingsController as ctrl'
+        }
+      }
+    });
+});


### PR DESCRIPTION
# Motivation

The portal application need to have a "Settings" section so users can perform administrative actions..

The first section of this Settings section will be to add an option to reset all data.

This feature is to allow developers and demos to easily reset the data to original state when using persistent stores.

# Changes

- Added a new directive for the settings section.
- Added a new service to be able to call a cloud endpoint to reset all data.