### PR TITLE
[RAINCATCH-451] Remove generated angular variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 www/
+.idea

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Brian Leathem",
   "license": "MIT",
   "dependencies": {
-    "angular": "1.5.3",
+    "angular": "1.5.9",
     "angular-animate": "1.5.3",
     "angular-aria": "1.5.3",
     "angular-material": "1.0.7",

--- a/src/app/workflow/workflow.js
+++ b/src/app/workflow/workflow.js
@@ -129,6 +129,7 @@ angular.module('app.workflow', [
   $scope.dragControlListeners = {
     containment: '#stepList',
     orderChanged :  function() {
+      workflow = JSON.parse(angular.toJson(workflow)); //remove generated angular variables
       workflowManager.update(workflow).then(function(_workflow) {
         $state.go('app.workflow.detail',
          {workflowId: _workflow.id},


### PR DESCRIPTION
## What
Remove generated angular variables causing $fh.db operations to fail. 

## JIRA Ticket 
https://issues.jboss.org/browse/RAINCATCH-451