### PR TITLE
[RAINCATCH-793] display group info upon group create or update

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fh-wfm-signature": "0.0.19",
     "fh-wfm-sync": "0.3.1",
     "fh-wfm-user": "0.6.3",
-    "fh-wfm-user-angular": "0.2.3",
+    "fh-wfm-user-angular": "0.2.4",
     "fh-wfm-vehicle-inspection": "0.0.15",
     "fh-wfm-workorder": "0.2.3",
     "fh-wfm-workflow": "0.2.4",


### PR DESCRIPTION
# What 

- Group information is not displayed when a group is created or updated. 
- Update user-angular to version with the bug fix. 

# JIRA
https://issues.jboss.org/browse/RAINCATCH-793