### PR TITLE
Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,15 @@ services:
   - mongodb
   - docker
 node_js:
-  - '0.10'
-  - '4.4'
+  - '4.4.3'
+  - '6.9.1'
 before_install:
   - npm install grunt-cli -g
 script:
   - npm test
-  - >-
-    bash <(curl
-    https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
-install: npm install
+  - bash <(curl https://gist.githubusercontent.com/raincatcher-bot/01ac4cdb3b0770bdb58489dbc17ed6b6/raw/6205a628c3616f6736fd866d5f0fba0a781ec1e4/sonarqube.sh)
+install:
+  - npm install
 notifications:
   email: false
   slack:

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A WFM2 PoC using the mediator pattern",
   "repository": "https://github.com/feedhenry-raincatcher/raincatcher-demo-portal.git",
   "engines": {
-    "node": "0.10.0",
-    "npm": "2.0.0"
+    "node": ">=4.4 <=6.10"
   },
   "main": "application.js",
   "scripts": {
@@ -18,8 +17,8 @@
   "author": "Brian Leathem",
   "license": "MIT",
   "dependencies": {
-    "cors": "2.7.1",
-    "express": "4.15.2"
+    "cors": "2.8.3",
+    "express": "4.15.3"
   },
   "devDependencies": {
     "angular": "1.6.1",


### PR DESCRIPTION
Node 6 support:
- Update travis.yml:
  - Remove Node 0.10 and add Node 6.9
- Update dependencies

JIRA: https://issues.jboss.org/browse/RHMAP-15493